### PR TITLE
fix: fetch comments count on proposals batch request

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -416,13 +416,26 @@ export const onFetchProposalsBatch = (tokens, state, fetchVoteSummary = true) =>
           tokens,
           state
         }),
-        fetchVoteSummary && dispatch(onFetchProposalsBatchVoteSummary(tokens))
+        fetchVoteSummary && dispatch(onFetchProposalsBatchVoteSummary(tokens)),
+        api.commentsCount(tokens, state)
       ]);
       const proposals = response.find((res) => res && res.proposals).proposals;
       const summaries =
         fetchVoteSummary &&
         response.find((res) => res && res.summaries).summaries;
-      dispatch(act.RECEIVE_PROPOSALS_BATCH({ proposals }));
+      const commentsCount = response.find((res) => res && res.counts).counts;
+      const proposalsWithCommentsCount = Object.keys(proposals).reduce(
+        (acc, curr) => {
+          return {
+            ...acc,
+            [curr]: { ...proposals[curr], commentsCount: commentsCount[curr] }
+          };
+        },
+        {}
+      );
+      dispatch(
+        act.RECEIVE_PROPOSALS_BATCH({ proposals: proposalsWithCommentsCount })
+      );
       return [proposals, summaries];
     } catch (e) {
       dispatch(act.RECEIVE_PROPOSALS_BATCH(null, e));

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -48,7 +48,6 @@ import VersionPicker from "src/components/VersionPicker";
 import useModalContext from "src/hooks/utils/useModalContext";
 import { useRouter } from "src/components/Router";
 import { isEmpty, getKeyByValue } from "src/helpers";
-import { useComments } from 'src/containers/Comments/hooks';
 
 /**
  * replaceImgDigestWithPayload uses a regex to parse images
@@ -129,10 +128,9 @@ const Proposal = React.memo(function Proposal({
     proposedFor,
     type,
     rfpSubmissions,
-    state
+    state,
+    commentsCount
   } = proposal;
-  console.log("in proposal")
-  console.log(proposal)
   const isRfp = !!linkby || type === PROPOSAL_TYPE_RFP;
   const isRfpSubmission = !!linkto || type === PROPOSAL_TYPE_RFP_SUBMISSION;
   const isRfpActive = isRfp && isActiveRfp(linkby);
@@ -145,9 +143,6 @@ const Proposal = React.memo(function Proposal({
     commentsURL,
     rfpProposalURL
   } = useProposalURLs(proposalToken, userid, isRfpSubmission, linkto, state);
-  const { comments } = useComments(proposalToken, state);
-  console.log("comments fetcehd from hook")
-  console.log(comments)
   const isPublic = isPublicProposal(proposal);
   const isVotingFinished = isVotingFinishedProposal(voteSummary);
   const isAbandoned = isAbandonedProposal(proposal);
@@ -368,9 +363,9 @@ const Proposal = React.memo(function Proposal({
                 onClick={goToFullProposal(history, proposalURL)}
               />
             )}
-            {isPublicAccessible && !extended && comments && (
+            {isPublicAccessible && !extended && (
               <Row justify="space-between">
-                <CommentsLink numOfComments={comments.length} url={commentsURL} />
+                <CommentsLink numOfComments={commentsCount} url={commentsURL} />
                 <div>
                   {(isVoteActive || isVotingFinished) && (
                     <ChartsLink token={proposalToken} />

--- a/src/components/Proposal/ProposalActions.jsx
+++ b/src/components/Proposal/ProposalActions.jsx
@@ -137,7 +137,9 @@ const PublicActions = ({
 
 const ProposalActions = ({ proposal, ...props }) =>
   proposal.state === PROPOSAL_STATE_UNVETTED ? (
-    <UnvettedActions proposal={proposal} />
+    <PublicActions {...{ ...props, proposal }}>
+      <UnvettedActions proposal={proposal} />
+    </PublicActions>
   ) : (
     <PublicActions {...{ ...props, proposal }} />
   );

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -522,6 +522,9 @@ export const user = (userId) => GET(`/user/${userId}`).then(getResponse);
 export const proposalComments = (csrf, token, state) =>
   POST("/comments", csrf, { token, state }, apiComments).then(getResponse);
 
+export const commentsCount = (tokens, state) =>
+  POST("/count", "", { tokens, state }, apiComments).then(getResponse);
+
 export const commentsTimestamps = (csrf, token, state, commentids) =>
   POST("/timestamps", csrf, { token, state, commentids }, apiComments).then(
     getResponse


### PR DESCRIPTION
This diff uses the `/count` endpoint on comments api to fetch comments count when a proposal batch call is done