### PR TITLE
tlog: fix action provider bug

### DIFF
--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -190,6 +190,11 @@ const proposals = (state = DEFAULT_STATE, action) =>
                   ),
                   [proposalToken(action.payload.proposal)]
                 )
+              ),
+              update(["allByStatusUnvetted"], (props) =>
+                props[UNREVIEWED].filter(
+                  (p) => p !== action.payload.proposal.censorshiprecord.token
+                )
               )
             )(state),
           [act.RECEIVE_USER_PROPOSALS]: () =>


### PR DESCRIPTION
This diff fixes the action provider bug by removing the proposal from our Unreviewed state tree once it gets its status set by an admin.
