### PR TITLE
tlog: fix filenames and content for bundle/timestamp downloads

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -391,6 +391,7 @@ const Proposal = React.memo(function Proposal({
                   <DownloadRecord
                     fileName={`${proposalToken}-v${version}`}
                     content={proposal}
+                    serverpubkey={apiInfo.pubkey}
                     label="Proposal Bundle"
                   />
                   <DownloadTimestamps

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -389,13 +389,9 @@ const Proposal = React.memo(function Proposal({
                   className={styles.downloadLinksWrapper}
                   title="Available Downloads">
                   <DownloadRecord
-                    fileName={proposalToken}
-                    content={{
-                      ...proposal,
-                      serverpublickey: apiInfo.pubkey
-                    }}
-                    className="margin-right-l"
-                    label="Download Proposal Bundle"
+                    fileName={`${proposalToken}-v${version}`}
+                    content={proposal}
+                    label="Proposal Bundle"
                   />
                   <DownloadTimestamps
                     label="Proposal Timestamps"

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -252,11 +252,11 @@ export const DownloadRecord = ({ content, ...rest }) => {
     censorshiprecord: content.censorshiprecord
   };
   return (
-  <DownloadJSON 
+  <DownloadJSON
     {...rest}
     content={proposal}
   />);
-}
+};
 
 export const DownloadTimestamps = ({ token, version, state, label }) => {
   const { onFetchRecordTimestamps } = useTimestamps();

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -239,7 +239,7 @@ export const RfpProposalLink = ({ url, rfpTitle }) => {
   );
 };
 
-export const DownloadRecord = ({ content, ...rest }) => {
+export const DownloadRecord = ({ content, fileName, label, serverpubkey }) => {
   // Build proposal data to match record type on backend.
   const proposal = {
     state: content.state,
@@ -249,11 +249,13 @@ export const DownloadRecord = ({ content, ...rest }) => {
     username: content.username,
     metadata: content.metadata,
     files: content.files,
-    censorshiprecord: content.censorshiprecord
+    censorshiprecord: content.censorshiprecord,
+    serverpubkey
   };
   return (
   <DownloadJSON
-    {...rest}
+    fileName={fileName}
+    label={label}
     content={proposal}
   />);
 };

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -239,14 +239,31 @@ export const RfpProposalLink = ({ url, rfpTitle }) => {
   );
 };
 
-export const DownloadRecord = DownloadJSON;
+export const DownloadRecord = ({ content, ...rest }) => {
+  // Build proposal data to match record type on backend.
+  const proposal = {
+    state: content.state,
+    status: content.status,
+    version: content.version,
+    timestamp: content.timestamp,
+    username: content.username,
+    metadata: content.metadata,
+    files: content.files,
+    censorshiprecord: content.censorshiprecord
+  };
+  return (
+  <DownloadJSON 
+    {...rest}
+    content={proposal}
+  />);
+}
 
 export const DownloadTimestamps = ({ token, version, state, label }) => {
   const { onFetchRecordTimestamps } = useTimestamps();
   return (
     <DownloadJSON
       label={label}
-      fileName={`timestamps-${token ? token.substring(0, 7) : ""}-v${version}`}
+      fileName={`${token}-v${version}-timestamps`}
       isAsync={true}
       content={[]}
       beforeDownload={() => onFetchRecordTimestamps(token, state, version)}

--- a/src/containers/Comments/Download/DownloadComments.jsx
+++ b/src/containers/Comments/Download/DownloadComments.jsx
@@ -30,9 +30,7 @@ const DownloadComments = ({
       <DownloadJSON
         label={label}
         isAsync={true}
-        fileName={`timestamp-${
-          recordToken ? recordToken.substring(0, 7) : ""
-        }-comments`}
+        fileName={`${recordToken}-comments-timestamps`}
         beforeDownload={() => onFetchCommentsTimestamps(recordToken, state)}
         content={[]}
       />


### PR DESCRIPTION
Fix proposal bundle content to match `Record` backend type, and fix filenames to match the following:

```
87d70baa54c3d53a-comments.json
87d70baa54c3d53a-comment-timestamps.json
87d70baa54c3d53a-v2.json
87d70baa54c3d53a-v2-timestamps.json
```